### PR TITLE
This fix properly assigns the ca value required by the getMyAccssIdCertInfo method.

### DIFF
--- a/sshca.go
+++ b/sshca.go
@@ -470,7 +470,7 @@ func sshsignHandler(w http.ResponseWriter, r *http.Request) (err error) {
 		return
 	}
 
-	ci := getMyAccssIdCertInfo(certInfo{}, res)
+	ci := getMyAccssIdCertInfo(certInfo{ca: ca}, res)
 	sshCertificate, err := newCertificate(config, publicKey, ci)
 	if err != nil {
 		return


### PR DESCRIPTION
The method getMyAccssIdCertInfo expects to receive a certInfo structure that contains a populated ca field in order to resolve the CA parameters:
```
ci.params = Config.CaConfigs[ci.ca].CAParams
```
This fix assigns the expected ca value before calling getMyAccssIdCertInfo.