### PR TITLE
Adds default timeout of 2 seconds for token request

### DIFF
--- a/deviceflow.go
+++ b/deviceflow.go
@@ -10,7 +10,7 @@ import (
 )
 
 func deviceflowHandler(w http.ResponseWriter, r *http.Request, token string, ca CaConfig, ci certInfo) (err error) {
-	resp, err := device_authorization_request(ca.ClientID, ca.Op.Device_authorization)
+	resp, err := device_authorization_request(ca.ClientID, ca.Op.Device_authorization, ca.Scopes)
 	if err != nil {
 		return
 	}
@@ -30,10 +30,10 @@ func deviceflowHandler(w http.ResponseWriter, r *http.Request, token string, ca 
 	return
 }
 
-func device_authorization_request(clientID, device_authorization string) (res DeviceResponse, err error) {
+func device_authorization_request(clientID, device_authorization, scopes string) (res DeviceResponse, err error) {
 	v := url.Values{}
 	v.Set("client_id", clientID)
-    v.Set("scope", "openid email profile eduperson_entitlement urn:geant:efp.core.aai.geant.org:res:it4i.cz:act:ssh")
+        v.Set("scope", scopes)
 	resp, err := client.PostForm(device_authorization, v)
 	if err != nil {
 		return

--- a/deviceflow.go
+++ b/deviceflow.go
@@ -14,17 +14,17 @@ func deviceflowHandler(w http.ResponseWriter, r *http.Request, token string, ca 
 	if err != nil {
 		return
 	}
-    tmpl.ExecuteTemplate(w, "deviceflow", map[string]any{"state": token, "verification_uri": resp.Verification_uri_complete})
-    go func(token string) {
+	tmpl.ExecuteTemplate(w, "deviceflow", map[string]any{"state": token, "verification_uri": resp.Verification_uri_complete})
+	go func(token string) {
 		tokenResponse, err := token_request(ca, resp)
 		if err == nil {
-            resp, err := introspect(tokenResponse.Access_token, ca)
-            if err != nil {
-                return
-            }
-	        if ci, ok := claims.get(token); ok {
-                claims.set(token, getMyAccssIdCertInfo(ci, resp))
-            }
+			resp, err := introspect(tokenResponse.Access_token, ca)
+			if err != nil {
+				return
+			}
+			if ci, ok := claims.get(token); ok {
+				claims.set(token, getMyAccssIdCertInfo(ci, resp))
+			}
 		}
 	}(token)
 	return

--- a/deviceflow.go
+++ b/deviceflow.go
@@ -54,7 +54,10 @@ func token_request(ca CaConfig, deviceResponse DeviceResponse) (res TokenRespons
 	v.Set("device_code", deviceResponse.Device_code)
 	v.Set("client_id", ca.ClientID)
 	tries := 10
-	timeout := deviceResponse.Interval * time.Second
+	timeout := 2 * time.Second
+	if deviceResponse.Interval != 0 {
+		timeout = deviceResponse.Interval * time.Second
+	}
 	for tries > 0 {
 		tries--
 		resp, err := client.PostForm(ca.Op.Token, v)

--- a/sshca.go
+++ b/sshca.go
@@ -78,8 +78,8 @@ type (
 
 	CaConfig struct {
 		Fake, Hide                                                                         bool
-		Id, Name, PublicKey, ConfigEndpoint                                string
-		SSHTemplate, HTMLTemplate                                                          string
+		Id, Name, PublicKey, ConfigEndpoint                                                string
+		SSHTemplate, HTMLTemplate, Scopes                                                  string
 		DefaultPrincipals, AuthnContextClassRef                                            []string
 		HashedPrincipal                                                                    bool
 		MyAccessID                                                                         bool
@@ -484,7 +484,7 @@ func introspect(token string, ca CaConfig) (res IntrospectionResponse, err error
 	data.Set("token", token)
 	data.Set("client_id", ca.IntroSpectClientID)
 	data.Set("client_secret", ca.IntroSpectClientSecret)
-	data.Set("scope", "openid email profile eduperson_entitlement urn:geant:efp.core.aai.geant.org:res:it4i.cz:act:ssh")
+        data.Set("scope", ca.Scopes)
 
 	request, _ := http.NewRequest("POST", ca.Op.Introspect, strings.NewReader(data.Encode()))
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
If deviceResponse.Interval is missing or set to 0 the for loop finishes too fast. Apply a default timeout of 2 seconds if deviceResponse.Interval is set to 0.